### PR TITLE
Avoid list allocations when removing HTML nodes

### DIFF
--- a/SemanticSlicer/Slicer.cs
+++ b/SemanticSlicer/Slicer.cs
@@ -128,8 +128,15 @@ namespace SemanticSlicer
 				title += $"{LINE_ENDING_REPLACEMENT}{LINE_ENDING_REPLACEMENT}";
 			}
 
-			// remove any script and style tags from body
-			body.SelectNodes("//script|//style")?.ToList().ForEach(node => node.Remove());
+                        // remove any script and style tags from body
+                        var nodes = body.SelectNodes("//script|//style");
+                        if (nodes != null)
+                        {
+                                foreach (var node in nodes)
+                                {
+                                        node.Remove();
+                                }
+                        }
 
 			return $"{title}{GetInnerTextWithSpaces(body).Trim()}";
 		}


### PR DESCRIPTION
## Summary
- remove extra `ToList` call when deleting HTML `script`/`style` nodes

## Testing
- `dotnet test --no-build` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_b_6853fa98365c83228253d9c2968082f2