### PR TITLE
Add support for custom tokenizers via IEncoder interface

### DIFF
--- a/SemanticSlicer/Encoding.cs
+++ b/SemanticSlicer/Encoding.cs
@@ -6,6 +6,10 @@
 	public enum Encoding
 	{
 		Cl100K,
-		O200K
-	}
+		O200K,
+    /// <summary>
+    /// Use custom implementation of IEncoder
+    /// </summary>
+    Custom
+  }
 }

--- a/SemanticSlicer/Encoding.cs
+++ b/SemanticSlicer/Encoding.cs
@@ -7,9 +7,9 @@
 	{
 		Cl100K,
 		O200K,
-    /// <summary>
-    /// Use custom implementation of IEncoder
-    /// </summary>
-    Custom
+		/// <summary>
+		/// Use custom implementation of IEncoder
+		/// </summary>
+		Custom
   }
 }

--- a/SemanticSlicer/Services/Encoders/IEncoder.cs
+++ b/SemanticSlicer/Services/Encoders/IEncoder.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SemanticSlicer.Services.Encoders
+{
+  public interface IEncoder
+  {
+    int CountTokens(string text);
+  }
+}

--- a/SemanticSlicer/Services/Encoders/IEncoder.cs
+++ b/SemanticSlicer/Services/Encoders/IEncoder.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace SemanticSlicer.Services.Encoders
 {
-  public interface IEncoder
-  {
-    int CountTokens(string text);
-  }
+  /// <summary>
+  /// Defines a contract for encoding text into tokens. Implement this interface to provide custom tokenization logic.
+  /// </summary>
+	public interface IEncoder
+	{
+		int CountTokens(string text);
+	}
 }

--- a/SemanticSlicer/Services/Encoders/TikTokEncoder.cs
+++ b/SemanticSlicer/Services/Encoders/TikTokEncoder.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SemanticSlicer.Services.Encoders
+{
+  internal class TikTokEncoder : IEncoder
+  {
+    private readonly Tiktoken.Encoder tiktokenEncoder;
+
+    public TikTokEncoder(Tiktoken.Encodings.Encoding encoding)
+    {
+      tiktokenEncoder = new Tiktoken.Encoder(encoding);
+    }
+
+    public int CountTokens(string text)
+      => tiktokenEncoder.CountTokens(text);
+  }
+}

--- a/SemanticSlicer/Services/Encoders/TikTokEncoder.cs
+++ b/SemanticSlicer/Services/Encoders/TikTokEncoder.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace SemanticSlicer.Services.Encoders
 {
-  internal class TikTokEncoder : IEncoder
-  {
-    private readonly Tiktoken.Encoder tiktokenEncoder;
+	internal class TikTokEncoder : IEncoder
+	{
+		private readonly Tiktoken.Encoder tiktokenEncoder;
 
-    public TikTokEncoder(Tiktoken.Encodings.Encoding encoding)
-    {
-      tiktokenEncoder = new Tiktoken.Encoder(encoding);
-    }
+		public TikTokEncoder(Tiktoken.Encodings.Encoding encoding)
+		{
+			tiktokenEncoder = new Tiktoken.Encoder(encoding);
+		}
 
-    public int CountTokens(string text)
-      => tiktokenEncoder.CountTokens(text);
-  }
+		public int CountTokens(string text)
+			=> tiktokenEncoder.CountTokens(text);
+	}
 }

--- a/SemanticSlicer/Slicer.cs
+++ b/SemanticSlicer/Slicer.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 
 using SemanticSlicer.Models;
-
+using SemanticSlicer.Services.Encoders;
 using Tiktoken.Encodings;
 
 namespace SemanticSlicer
@@ -28,7 +28,7 @@ namespace SemanticSlicer
 		};
 
 		private SlicerOptions _options;
-		private readonly Tiktoken.Encoder _encoder;
+		private readonly IEncoder _encoder;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Slicer"/> class with optional SemanticSlicer options.
@@ -47,14 +47,20 @@ namespace SemanticSlicer
 		/// <param name="encoding">The encoding type to use for the encoder.</param>
 		/// <returns>A Tiktoken.Encoder instance corresponding to the specified encoding.</returns>
 		/// <exception cref="ArgumentException">Thrown if the specified encoding is not supported.</exception>
-		private Tiktoken.Encoder GetEncoder(Encoding encoding)
+		private IEncoder GetEncoder(Encoding encoding)
 		{
 			switch (encoding)
 			{
 				case Encoding.O200K:
-					return new Tiktoken.Encoder(new O200KBase());
+					return new TikTokEncoder(new O200KBase());
 				case Encoding.Cl100K:
-					return new Tiktoken.Encoder(new Cl100KBase());
+					return new TikTokEncoder(new Cl100KBase());
+				case Encoding.Custom:
+					{
+						if (_options.CustomEncoder == null)
+							throw new ArgumentException($"CustomEncoder was not set in the options.");
+						return _options.CustomEncoder;
+					}
 				default:
 					throw new ArgumentException($"Encoding {encoding} is not supported.");
 			}

--- a/SemanticSlicer/SlicerOptions.cs
+++ b/SemanticSlicer/SlicerOptions.cs
@@ -25,7 +25,7 @@ namespace SemanticSlicer
 		public Encoding Encoding { get; set; } = Encoding.Cl100K;
 
 		/// <summary>
-		/// 
+		/// Gets or sets the custom encoder implementation. Required when <see cref="Encoding"/> is set to <c>Encoding.Custom</c>. Can be null for other encoding types.
 		/// </summary>
 		public IEncoder CustomEncoder { get; set; }
 

--- a/SemanticSlicer/SlicerOptions.cs
+++ b/SemanticSlicer/SlicerOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using SemanticSlicer.Models;
+using SemanticSlicer.Services.Encoders;
 
 namespace SemanticSlicer
 {
@@ -18,10 +19,15 @@ namespace SemanticSlicer
 		/// </summary>
 		public int MinChunkPercentage { get; set; } = 10;
 
+    /// <summary>
+    /// Gets or sets the encoding used for semantic processing. Default is "cl100k_base".
+    /// </summary>
+    public Encoding Encoding { get; set; } = Encoding.Cl100K;
+
 		/// <summary>
-		/// Gets or sets the encoding used for semantic processing. Default is "cl100k_base".
+		/// 
 		/// </summary>
-		public Encoding Encoding { get; set; } = Encoding.Cl100K;
+		public IEncoder CustomEncoder { get; set; }
 
 		/// <summary>
 		/// Gets or sets the separators used for splitting documents. Default is Separators.Text.

--- a/SemanticSlicer/SlicerOptions.cs
+++ b/SemanticSlicer/SlicerOptions.cs
@@ -19,10 +19,10 @@ namespace SemanticSlicer
 		/// </summary>
 		public int MinChunkPercentage { get; set; } = 10;
 
-    /// <summary>
-    /// Gets or sets the encoding used for semantic processing. Default is "cl100k_base".
-    /// </summary>
-    public Encoding Encoding { get; set; } = Encoding.Cl100K;
+		/// <summary>
+		/// Gets or sets the encoding used for semantic processing. Default is "cl100k_base".
+		/// </summary>
+		public Encoding Encoding { get; set; } = Encoding.Cl100K;
 
 		/// <summary>
 		/// 


### PR DESCRIPTION
Previously SemanticSlicer supported only two built-in Tiktoken encodings (Cl100KBase and O200KBase).
This commit introduces a new option Encoding.Custom and a new IEncoder interface that allows passing any custom tokenizer implementation.
This makes the splitter compatible with arbitrary HuggingFace or other tokenizers and removes the limitation to the two built-in encodings.